### PR TITLE
fix: remove white gap between Hero and Footer

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -48,7 +48,7 @@ export default async function HomePage({ params }: Props) {
   setRequestLocale(locale);
 
   return (
-    <main className="min-h-screen">
+    <main>
       {/* Hero Section */}
       <Hero />
 


### PR DESCRIPTION
Fixes #4

Removed the `min-h-screen` class from the main page element that was causing unwanted white space between the Hero and Footer components. The layout component's flexbox design already properly handles page height.

Generated with [Claude Code](https://claude.ai/code)